### PR TITLE
レイアウト修正。画像1枚1枚がはっきり見えるように

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,7 @@ class _AnimalListPageState extends State<AnimalListPage> {
                   child: Text(
                     animal['name'],
                     style: TextStyle(
-                      fontSize: 15,
+                      fontSize: 10,
                       fontWeight: FontWeight.bold,
                     ),
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,7 @@ class _AnimalListPageState extends State<AnimalListPage> {
             mainAxisSpacing: 8,
             crossAxisSpacing:16,
             crossAxisCount: 2,
-            childAspectRatio: 0.8,
+            childAspectRatio: 0.7,
 
           ),
           scrollDirection: Axis.vertical,
@@ -131,7 +131,7 @@ class _AnimalListPageState extends State<AnimalListPage> {
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: Text(
                     animal['description'],
-                    maxLines: 2,
+                    maxLines: 3,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
                       fontSize: 14,


### PR DESCRIPTION
## 概要

メインページの画像1枚1枚が背景と同化していたので、１まいがくっきり見えるように修正しました

### 見てほしい点
xxxというウィジェットを使ったのですが、しらべたところ書き方が古いかもしれないですURL:xxx 
問題ないかご確認いただきたいです。